### PR TITLE
Calculate absolute URL within the worker to catch relative URLs in payloads

### DIFF
--- a/platinum-push-messaging.html
+++ b/platinum-push-messaging.html
@@ -21,6 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var SCOPE = new URL('./$$platinum-push-messaging$$/', currentScript).href;
     var WORKER_URL = new URL('./service-worker.js', currentScript).href;
 
+    var BASE_URL = new URL('./', document.location.href).href;
+
     var SUPPORTED = 'serviceWorker' in navigator &&
         'PushManager' in window  &&
         'Notification' in window;
@@ -233,18 +235,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * Resolves a URL that is relative to the page to an absolute URL
-       *
-       * @param url {String} a relative URL
-       * @return {String} the equivalent absolute URL
-       */
-      _absUrl: function(url) {
-        if (typeof(url) === 'string') {
-          return new URL(url, document.location).href;
-        }
-      },
-
-      /**
        * Event handler for the `message` event.
        *
        * @param event {MessageEvent}
@@ -289,12 +279,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _getWorkerURL: function() {
         var options = this._serializeOptions({
           tag: this.tag,
-          messageUrl: this._absUrl(this.messageUrl),
+          messageUrl: this.messageUrl,
           title: this.title,
           message: this.message,
-          iconUrl: this._absUrl(this.iconUrl),
-          clickUrl: this._absUrl(this.clickUrl),
-          version: VERSION
+          iconUrl: this.iconUrl,
+          clickUrl: this.clickUrl,
+          version: VERSION,
+          baseUrl: BASE_URL
         });
 
         return WORKER_URL + '?' + options;

--- a/service-worker.js
+++ b/service-worker.js
@@ -15,6 +15,18 @@ var DATA_SUPPORT = Notification.prototype.hasOwnProperty('data');
 
 self.skipWaiting();
 
+/**
+ * Resolves a URL that is relative to the registering page to an absolute URL
+ *
+ * @param url {String} a relative URL
+ * @return {String} the equivalent absolute URL
+ */
+var absUrl = function(url) {
+  if (typeof(url) === 'string') {
+    return new URL(url, options.baseUrl).href;
+  }
+};
+
 var getClientWindows = function() {
   return clients.matchAll({
     type: 'window',
@@ -49,7 +61,7 @@ var notify = function(data) {
   var messagePromise;
 
   if (options.messageUrl) {
-    messagePromise = fetch(options.messageUrl).then(function(response) {
+    messagePromise = fetch(absUrl(options.messageUrl)).then(function(response) {
       return response.json();
     });
   } else {
@@ -61,11 +73,11 @@ var notify = function(data) {
       title: message.title || options.title || '',
       body: message.message || options.message || '',
       tag: message.tag || options.tag || DEFAULT_TAG,
-      icon: message.icon || options.iconUrl,
+      icon: absUrl(message.icon || options.iconUrl),
       data: message
     };
 
-    var clickUrl = message.url || options.clickUrl;
+    var clickUrl = absUrl(message.url || options.clickUrl);
 
     if (!DATA_SUPPORT) {
       // If there is no 'data' property support on the notification then we have
@@ -97,7 +109,7 @@ var clickHandler = function(notification) {
     message = JSON.parse(decodeURIComponent(message));
   }
 
-  var url = message.url || options.clickUrl;
+  var url = absUrl(message.url || options.clickUrl);
 
   if (!url) {
     return;


### PR DESCRIPTION
Previously, if your payload had a relative URL (for image, or click URL), this would be resolved relative to the scope of the worker, not the page that configured the worker.
