### PR TITLE
fix messageUrl docs

### DIFF
--- a/platinum-push-messaging.html
+++ b/platinum-push-messaging.html
@@ -154,7 +154,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          * ```
          * {
          *   "title": "The title for the notification",
-         *   "body": "The message to display in the notification",
+         *   "message": "The message to display in the notification",
          *   "url": "The URL to display when the notification is clicked",
          *   "icon": "The URL of an icon to display with the notification",
          *   "tag": "An identifier that determines which notifications can be displayed at the same time"


### PR DESCRIPTION
I think the correct property name is `message` not `body` (that's what works in practice), so updating the docs to match it.
