### PR TITLE
URI encode the options JSON to allow for characters like #

### DIFF
--- a/platinum-push-messaging.html
+++ b/platinum-push-messaging.html
@@ -303,7 +303,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }).map(function(propName) {
           return JSON.stringify(propName) + ':' + JSON.stringify(options[propName]);
         });
-        return '{' + parts.join(',') + '}';
+        return encodeURIComponent('{' + parts.join(',') + '}');
       },
 
       /**


### PR DESCRIPTION
Fix for the issue that @jeffposnick had with URLs that had `#` in.

R: @jeffposnick 