### PR TITLE
remove listener to WebComponentsReady

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -93,7 +93,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </div>
 
     <script>
-    document.addEventListener('WebComponentsReady', function() {
       var ppm = document.querySelector('platinum-push-messaging');
       var toggle = document.getElementById('enable-push');
       var subscription = document.getElementById('subscription');
@@ -132,7 +131,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         toggle.checked = ppm.enabled;
         sendInstructions.style.display = ppm.enabled ? '' : 'none';
       });
-    });
     </script>
   </body>
 </html>


### PR DESCRIPTION
`WebComponentsReady` gets called later than it used to be, which means that the `enabled-changed` (and friends) events we're listening to have already fired by the time we've set up the listeners. The observable effect is that the initial state is incorrectly displayed.

I'm not super sure why we need to make sure WebComponentsReady has fired (is it `fetch`?), so here's a PR that removes it. Feel free to yell at me if it's wrong.

/cc @addyosmani @wibblymat @jeffposnick 
