### PR TITLE
Added a "focus-url" property.

### DIFF
--- a/platinum-push-messaging.html
+++ b/platinum-push-messaging.html
@@ -285,6 +285,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           type: String,
           value: document.location.href
         },
+
+        /**
+         * When a user clicks the notification, there could be a number of different
+         * windows available that the service worker controls.  The default behavior
+         * is to open a new window unless the exact window with the desired URL is
+         * already open (in which case that window receives a "platinum-push-messaging-click"
+         * event).
+         *
+         * By specifying a focus URL here, instead of requiring an exact match, any
+         * window with a URL that begins with this one will be used.  This may be
+         * beneficial for single-page apps that do hash-based routing.
+         *
+         * This may be either a relative URL or an absolute one.
+         */
+        focusUrl: String,
       },
 
       /**
@@ -415,6 +430,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           message: this.message,
           iconUrl: this.iconUrl,
           clickUrl: this.clickUrl,
+          focusUrl: this.focusUrl,
           dir: this.dir,
           lang: this.lang,
           noscreen: this.noscreen,

--- a/service-worker.js
+++ b/service-worker.js
@@ -132,13 +132,42 @@ var clickHandler = function(notification) {
     return;
   }
 
+  // This is the focus URL.  If the "focus-url" property was not set, then this
+  // will be undefined and will not be used.
+  var focusUrl = absUrl( options.focusUrl );
+
   return getClientWindows().then(function(clientList) {
+    // Go through the windows that this service worker controls.
+    // Focus the first one that matches the message's URL.
+    //
+    // Attempt to match the first client that already has the desired URL open.
+    //
+    // Otherwise, if this service worker was configured with a "focus-url", then
+    // attempt to match the first client that begins with that URL.
+    //
+    // A client matched in this way will receive a "platinum-push-messaging-*"
+    // event.
+    //
+    // Finally, if no client was matched, then open up a new window to
+    // show the URL.  This window will NOT receive a "platinum-push-messaging-*"
+    // event.
     for (var client of clientList) {
-      if (client.url === url && 'focus' in client) {
+      // Exclude client instances that do not support the properties that we need.
+      if (!('url' in client) || !('focus' in client)) {
+        continue;
+      }
+      // See if the client URL that we want is already up somewhere.
+      // Otherwise, see if there is a window that starts with the focus URL
+      // already open.
+      if(client.url === url) {
+        client.focus();
+        return client;
+      } else if (focusUrl && client.url.startsWith(focusUrl)) {
         client.focus();
         return client;
       }
     }
+    // If no existing window could be used, then open a new one.
     if ('openWindow' in clients) {
       return clients.openWindow(url);
     }


### PR DESCRIPTION
The big problem that I ran into when working with "platinum-push-messaging" on
Android (as a "home screen" app) was that clicking the notification would not
behave as expected.

If the app was closed, then clicking on it opened the app to the desired URL
(the value of the message "url" field).  However, if the app was already up
or open in the background, then clicking on a notification simply refocused
the app.  This did not trigger the "platinum-push-messaging-click" event, and
it was pretty useless; my app needed the URL to change (it used hash routing).

The service-worker requirement for a 100% exact URL match, while conservative,
does not match with the philosophy of single-page apps.  Essentially, if my app
is open anywhere, then it should be focused and sent the click event, which my
app could then handle appropriately.

I've done testing on Chrome 52 for Android and Linux, and everything works as I'd expect it to.  If "focus-url" is unspecified (the default), then everything behaves exactly as it did previously.