### PR TITLE
Notify when "supported" changes.

### DIFF
--- a/platinum-push-messaging.html
+++ b/platinum-push-messaging.html
@@ -124,6 +124,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         supported: {
           readOnly: true,
           type: Boolean,
+          notify: true,
           value: function() { return SUPPORTED; }
         },
 


### PR DESCRIPTION
This was significant for me because I was loading the "platinum-push-messaging" element within a "dom-if" template.  I was able to bind to "enabled", but my app shows a separate message if the browser doesn't support push-messaging yet.

By adding "notify: true" to the "supported" property, it allowed me to bind to the "platinum-push-messaging" element within a "dom-if".
